### PR TITLE
Add import messages & reorganize destroy all order

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -5,9 +5,9 @@ namespace :import do
 
     Merchant.destroy_all
     Item.destroy_all
+    Customer.destroy_all
     Invoice.destroy_all
     InvoiceItem.destroy_all
-    Customer.destroy_all
     Transaction.destroy_all
 
     merchants
@@ -29,6 +29,7 @@ namespace :import do
         updated_at: merchant[:updated_at]
       )
     end
+    puts "Created #{Merchant.count} merchants!"
   end
 
   def items
@@ -43,6 +44,7 @@ namespace :import do
         updated_at: item[:updated_at]
       )
     end
+    puts "Created #{Item.count} items!"
   end
 
   def invoices
@@ -56,6 +58,7 @@ namespace :import do
         updated_at: invoice[:updated_at]
       )
     end
+    puts "Created #{Invoice.count} invoices!"
   end
 
   def invoice_items
@@ -70,6 +73,7 @@ namespace :import do
         updated_at: invoice_item[:updated_at]
       )
     end
+    puts "Created #{InvoiceItem.count} invoice items!"
   end
 
   def customers
@@ -82,6 +86,7 @@ namespace :import do
         updated_at: customer[:updated_at]
       )
     end
+    puts "Created #{Customer.count} customers!"
   end
 
   def transactions
@@ -96,5 +101,6 @@ namespace :import do
         updated_at: transaction[:updated_at]
       )
     end
+    puts "Created #{Transaction.count} transactions!"
   end
 end


### PR DESCRIPTION
Hey Daniel! I added examples of import messages you can use so that you can see things being imported. 

I also reorganized the destroy all order for the import command to resolve this error I got after trying to re-import: update or delete on table "merchants" violates foreign key constraint "fk_rails_ba3b0b4b5e" on table "items". It just aligns it to the same order you used to import everything. 